### PR TITLE
Fix duplicate step definition

### DIFF
--- a/mPartial_Cypress/cypress/e2e/adminAllOrders/adminAllOrders.ts
+++ b/mPartial_Cypress/cypress/e2e/adminAllOrders/adminAllOrders.ts
@@ -74,10 +74,6 @@ When('the admin notes the first row under "{string}"', (tabLabel: string) => {
     });
 });
 
-When('the admin clicks the "{string}" tab', (tabLabel: string) => {
-  // reuse the same click logic
-  cy.get(".nav-tabs").contains(tabLabel).click();
-});
 
 Then("the first row under Symbility is different from Xactimate", () => {
   cy.get("table tbody tr")


### PR DESCRIPTION
## Summary
- remove redundant step for clicking order tabs

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6852a4aca234832fb7d89362c0d371c5